### PR TITLE
Refactor faculty view to be subject-driven

### DIFF
--- a/custom_query_builder.py
+++ b/custom_query_builder.py
@@ -2,7 +2,7 @@ import streamlit as st
 import pandas as pd
 from pymongo import MongoClient
 
-def custom_query_builder_panel(db):
+def custom_query_builder_panel(db, subject_code=None):
     """A panel for building custom queries on student grades."""
     st.header("🔎 Custom Query Builder")
     st.info("Build filtered queries, e.g., 'Show all students with < 75 in CS101'.")
@@ -10,7 +10,7 @@ def custom_query_builder_panel(db):
     # --- UI Components ---
     col1, col2, col3 = st.columns(3)
     with col1:
-        program_code = st.text_input("Program Code (e.g., IT103)")
+        program_code = st.text_input("Program Code (e.g., IT103)", value=subject_code if subject_code else "")
     with col2:
         operator = st.selectbox("Operator", ["<", ">", "<=", ">=", "="])
     with col3:

--- a/faculty.py
+++ b/faculty.py
@@ -35,7 +35,7 @@ def get_subject_description(subject_code, db=None):
     return f"Description for {subject_code}"
 
 
-def class_grade_distribution_report(db, teacher_name):
+def class_grade_distribution_report(db, teacher_name, subject_code=None):
     st.subheader("📊 Class Grade Distribution Report")
 
     # Get semester list
@@ -63,7 +63,7 @@ def class_grade_distribution_report(db, teacher_name):
         return
 
     # Get data for the table
-    df_dist = get_grade_distribution_by_faculty(db, teacher_name, selected_semester_id)
+    df_dist = get_grade_distribution_by_faculty(db, teacher_name, selected_semester_id, subject_code=subject_code)
 
     if df_dist.empty:
         st.warning("No data found for the selected criteria.")
@@ -131,10 +131,33 @@ def class_grade_distribution_report(db, teacher_name):
         st.plotly_chart(fig, use_container_width=True)
 
 
-# ---------- FACULTY DASHBOARD ----------
-def faculty_dashboard(selected_teacher_name, df, subjects_map, semesters_map, db=None):
-    st.subheader("👩‍🏫 Faculty Dashboard")
-    st.info(f"Welcome, {selected_teacher_name}!")
+# ---------- ENTRY POINT ----------
+def faculty(df, semesters_map, db, role, username):
+    st.header("📘 Class Record")
+    st.info("This report provides a detailed view of student performance in a specific subject.")
+    if db is None:
+        st.warning("⚠️ Database connection not available.")
+        return
+
+    # Build subjects_map from DB
+    subjects_cursor = db["subjects"].find({}, {"_id": 1, "Description": 1, "Units": 1, "Teacher": 1})
+    subjects_map = {doc["_id"]: doc for doc in subjects_cursor}
+
+    selected_teacher_name = None
+    if role == 'faculty':
+        teacher_list = sorted({subj.get("Teacher") for subj in subjects_map.values() if subj.get("Teacher")})
+        if not teacher_list:
+            st.warning("⚠️ No teachers found in subjects mapping.")
+            return
+        selected_teacher_name = st.selectbox("Select Teacher", [""] + teacher_list, key="faculty_teacher")
+    elif role == 'teacher':
+        selected_teacher_name = username
+
+    if not selected_teacher_name:
+        st.info("Please select a teacher to continue.")
+        return
+
+    st.markdown("---")
 
     # Build DataFrame from subjects_map
     taught_subjects_df = pd.DataFrame(list(subjects_map.values()))
@@ -168,169 +191,21 @@ def faculty_dashboard(selected_teacher_name, df, subjects_map, semesters_map, db
     # (You can add logic here to display subject-specific info)
     st.success(f"You selected subject: {selected_subject_code}")
 
-    st.markdown(f"#### 📑 Class Report for {selected_subject_code}")
+    # Render all the reports for the selected subject
+    st.header("📊 Class Grade Distribution")
+    class_grade_distribution_report(db, selected_teacher_name, subject_code=selected_subject_code)
 
-    subject_grades = []
-    for _, row in df.iterrows():
-        if isinstance(row["SubjectCodes"], list) and selected_subject_code in row["SubjectCodes"]:
-            try:
-                subject_info = subjects_map.get(selected_subject_code, {})
-                if subject_info.get("Teacher") == selected_teacher_name:
-                    idx = row["SubjectCodes"].index(selected_subject_code)
-                    grade = pd.to_numeric(row["Grades"][idx], errors="coerce") if idx < len(row["Grades"]) else None
-                    grade = min(100, grade) if pd.notna(grade) else grade
-                    subject_grades.append({
-                        "StudentID": row["StudentID"],
-                        "StudentName": row["Name"],
-                        "Course": row["Course"],
-                        "YearLevel": row["YearLevel"],
-                        "SemesterID": row.get("SemesterID", None),
-                        "Grade": grade,
-                    })
-            except (ValueError, IndexError):
-                continue
+    st.header("📈 Student Progress Tracker")
+    student_progress_tracker_panel(db, teacher_name=selected_teacher_name, subject_code=selected_subject_code)
 
-    if not subject_grades:
-        st.warning("No grade records found for this subject under your name.")
-        return
+    st.header("🔥 Subject Difficulty Heatmap")
+    subject_difficulty_heatmap_panel(db, teacher_name=selected_teacher_name, subject_code=selected_subject_code)
 
-    df_subject_grades = pd.DataFrame(subject_grades).dropna(subset=["Grade"])
-    df_subject_grades = df_subject_grades.sort_values(by=["YearLevel", "StudentName"]).reset_index(drop=True)
-    df_subject_grades["Remarks"] = df_subject_grades["Grade"].apply(lambda x: "Passed" if x >= 75 else "Failed")
+    st.header("🧑‍🏫 Intervention Candidates List")
+    intervention_candidates_list_panel(db, teacher_name=selected_teacher_name, subject_code=selected_subject_code)
 
-    # Overall class stats
-    avg_gpa = df_subject_grades["Grade"].mean()
-    total_students = df_subject_grades.shape[0]
+    st.header("📝 Grade Submission Status")
+    grade_submission_status_panel(db, teacher_name=selected_teacher_name, subject_code=selected_subject_code)
 
-    col1, col2 = st.columns(2)
-    col1.metric("Class GPA", f"{avg_gpa:.2f}")
-    col2.metric("Total Students", total_students)
-
-    # ---------- GROUP BY YEAR ----------
-    grouped_by_year = df_subject_grades.groupby("YearLevel")
-    for year_level, group_df in grouped_by_year:
-        st.markdown(f"### 🎓 Year Level {year_level}")
-
-        col1, col2, col3, col4 = st.columns(4)
-        col1.metric("Mean Grade", f"{group_df['Grade'].mean():.2f}")
-        col2.metric("Median Grade", f"{group_df['Grade'].median():.2f}")
-        col3.metric("Highest Grade", f"{group_df['Grade'].max():.2f}")
-        col4.metric("Lowest Grade", f"{group_df['Grade'].min():.2f}")
-
-        styled_df = group_df.style.applymap(highlight_failed, subset=["Remarks"])
-        st.dataframe(styled_df, use_container_width=True)
-
-        # Histogram
-        st.markdown(f"📊 Grade Distribution for Year Level {year_level}")
-        fig_hist, ax_hist = plt.subplots(figsize=(10, 6))
-        bins = range(60, 101, 5)
-        n_hist, bins_hist, patches_hist = ax_hist.hist(group_df["Grade"], bins=bins, edgecolor="black")
-        ax_hist.set_xlabel("Grades")
-        ax_hist.set_ylabel("Frequency")
-        ax_hist.set_xticks(bins)
-        for i in range(len(n_hist)):
-            if n_hist[i] > 0:
-                ax_hist.text(
-                    bins_hist[i] + (bins_hist[1] - bins_hist[0]) / 2,
-                    n_hist[i],
-                    int(n_hist[i]),
-                    ha="center",
-                    va="bottom",
-                )
-        st.pyplot(fig_hist)
-        plt.close(fig_hist)
-
-        # Pass vs Fail
-        st.markdown(f"📊 Pass vs Fail for Year Level {year_level}")
-        pass_count = group_df[group_df["Remarks"] == "Passed"].shape[0]
-        fail_count = group_df[group_df["Remarks"] == "Failed"].shape[0]
-        fig_pf, ax_pf = plt.subplots(figsize=(6, 4))
-        bars = ax_pf.bar(["Pass", "Fail"], [pass_count, fail_count], color=["green", "red"])
-        for bar in bars:
-            yval = bar.get_height()
-            ax_pf.text(bar.get_x() + bar.get_width() / 2, yval, int(yval), ha="center", va="bottom")
-        st.pyplot(fig_pf)
-        plt.close(fig_pf)
-
-        st.markdown("---")
-
-    # ---------- DOWNLOAD REPORTS ----------
-    st.markdown("### 💾 Download Class Report")
-
-    excel_bytes = generate_excel(df_subject_grades, "faculty_class_report.xlsx")
-    st.download_button(
-        label="⬇️ Download as Excel",
-        data=excel_bytes,
-        file_name=f"FacultyReport_{selected_subject_code}.xlsx",
-        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    )
-
-
-# ---------- ENTRY POINT ----------
-def faculty(df, semesters_map, db, role, username):
-    if db is None:
-        st.warning("⚠️ Database connection not available.")
-        return
-
-    # Build subjects_map from DB
-    subjects_cursor = db["subjects"].find({}, {"_id": 1, "Description": 1, "Units": 1, "Teacher": 1})
-    subjects_map = {doc["_id"]: doc for doc in subjects_cursor}
-
-    selected_teacher_name = None
-    if role == 'faculty':
-        teacher_list = sorted({subj.get("Teacher") for subj in subjects_map.values() if subj.get("Teacher")})
-        if not teacher_list:
-            st.warning("⚠️ No teachers found in subjects mapping.")
-            return
-        selected_teacher_name = st.selectbox("Select Teacher", [""] + teacher_list, key="faculty_teacher")
-    elif role == 'teacher':
-        selected_teacher_name = username
-
-    if not selected_teacher_name:
-        st.info("Please select a teacher to continue.")
-        return
-
-    st.markdown("---")
-
-    # Dropdown for report selection
-    report_options = [
-        "📘 Class Report",
-        "📊 Class Grade Distribution",
-        "📈 Student Progress Tracker",
-        "🔥 Subject Difficulty Heatmap",
-        "🧑‍🏫 Intervention Candidates List",
-        "📝 Grade Submission Status",
-        "🔎 Custom Query Builder"
-    ]
-
-    selected_report = st.selectbox("Select a Report", report_options)
-
-    # Render the selected report
-    if selected_report == "📘 Class Report":
-        st.header("📘 Class Report")
-        st.info("This report provides a detailed view of student performance in a specific subject.")
-        faculty_dashboard(selected_teacher_name, df, subjects_map, semesters_map, db)
-
-    elif selected_report == "📊 Class Grade Distribution":
-        st.header("📊 Class Grade Distribution")
-        st.info("This report shows the grade distribution across different programs for the selected semester.")
-        class_grade_distribution_report(db, selected_teacher_name)
-
-    elif selected_report == "📈 Student Progress Tracker":
-        st.header("📈 Student Progress Tracker")
-        st.info("This report shows the longitudinal performance for individual students.")
-        student_progress_tracker_panel(db, teacher_name=selected_teacher_name)
-
-    elif selected_report == "🔥 Subject Difficulty Heatmap":
-        st.header("🔥 Subject Difficulty Heatmap")
-        st.info("This report visualizes subjects with high failure or dropouts.")
-        subject_difficulty_heatmap_panel(db, teacher_name=selected_teacher_name)
-
-    elif selected_report == "🧑‍🏫 Intervention Candidates List":
-        intervention_candidates_list_panel(db, teacher_name=selected_teacher_name)
-
-    elif selected_report == "📝 Grade Submission Status":
-        grade_submission_status_panel(db, teacher_name=selected_teacher_name)
-
-    elif selected_report == "🔎 Custom Query Builder":
-        custom_query_builder_panel(db)
+    st.header("🔎 Custom Query Builder")
+    custom_query_builder_panel(db, subject_code=selected_subject_code)

--- a/grade_submission_status.py
+++ b/grade_submission_status.py
@@ -3,7 +3,7 @@ import pandas as pd
 from pymongo import MongoClient
 from helpers.utils import generate_excel
 
-def grade_submission_status_panel(db, teacher_name=None):
+def grade_submission_status_panel(db, teacher_name=None, subject_code=None):
     """Displays the status of grade submissions by faculty."""
     st.header("📝 Grade Submission Status")
     st.info("This report tracks the status of grade submissions for each class taught by the selected faculty member for a given semester.")
@@ -78,6 +78,9 @@ def grade_submission_status_panel(db, teacher_name=None):
         return
 
     df_summary = pd.DataFrame(submission_summary)
+
+    if subject_code:
+        df_summary = df_summary[df_summary['programCode'] == subject_code]
 
     # Add programName from subjects collection
     subject_codes = df_summary['programCode'].unique().tolist()

--- a/intervention_candidates_list.py
+++ b/intervention_candidates_list.py
@@ -15,7 +15,7 @@ def get_risk_flag(grade):
         return "Invalid Grade Format"
     return None
 
-def intervention_candidates_list_panel(db, teacher_name=None):
+def intervention_candidates_list_panel(db, teacher_name=None, subject_code=None):
     """Displays a list of students at academic risk."""
     st.header("🧑‍🏫 Intervention Candidates List")
     st.info("This report lists students at academic risk based on low or missing grades for the selected semester.")
@@ -71,6 +71,9 @@ def intervention_candidates_list_panel(db, teacher_name=None):
         return
 
     df_candidates = pd.DataFrame(candidates_data)
+
+    if subject_code:
+        df_candidates = df_candidates[df_candidates['SubjectCode'] == subject_code]
 
     # Add programName from curriculum
     program_codes = df_candidates['programCode'].unique().tolist()

--- a/student_progress_tracker.py
+++ b/student_progress_tracker.py
@@ -36,7 +36,7 @@ def get_trend(grades):
 
     return "Stable"
 
-def student_progress_tracker_panel(db, teacher_name=None):
+def student_progress_tracker_panel(db, teacher_name=None, subject_code=None):
     if teacher_name is None:
         st.header("Student Progress Tracker")
         # Filters for registrar view
@@ -51,7 +51,7 @@ def student_progress_tracker_panel(db, teacher_name=None):
             year_level_list = [""] + sorted(db["students"].distinct("YearLevel"))
             selected_year_level = st.selectbox("Filter by Year Level", year_level_list, key="spt_year")
     else:
-        selected_subject = None
+        selected_subject = subject_code
         selected_course = None
         selected_year_level = None
 
@@ -85,14 +85,13 @@ def student_progress_tracker_panel(db, teacher_name=None):
         st.warning("No data found.")
         return
 
-    # Apply filters if not in teacher view
-    if teacher_name is None:
-        if selected_subject:
-            df = df[df['SubjectCodes'].apply(lambda x: selected_subject in x if isinstance(x, list) else False)]
-        if selected_course:
-            df = df[df['Course'] == selected_course]
-        if selected_year_level:
-            df = df[df['YearLevel'] == selected_year_level]
+    # Apply filters
+    if selected_subject:
+        df = df[df['SubjectCodes'].apply(lambda x: selected_subject in x if isinstance(x, list) else False)]
+    if selected_course:
+        df = df[df['Course'] == selected_course]
+    if selected_year_level:
+        df = df[df['YearLevel'] == selected_year_level]
 
     if df.empty:
         st.warning("No students found for the selected filters.")

--- a/subject_difficulty_heatmap.py
+++ b/subject_difficulty_heatmap.py
@@ -26,7 +26,7 @@ def get_difficulty_level(fail_rate, dropout_rate):
     else:
         return "Low"
 
-def subject_difficulty_heatmap_panel(db, teacher_name=None):
+def subject_difficulty_heatmap_panel(db, teacher_name=None, subject_code=None):
     if teacher_name is None:
         st.header("Subject Difficulty Heatmap")
 
@@ -94,6 +94,9 @@ def subject_difficulty_heatmap_panel(db, teacher_name=None):
         return
 
     display_df = pd.DataFrame(subject_stats)
+
+    if subject_code:
+        display_df = display_df[display_df['programCode'] == subject_code]
 
     # Styling for heatmap effect
     def style_rates(val):


### PR DESCRIPTION
This refactoring changes the faculty view to be centered around subject selection. Instead of a dropdown to select different reports, the user now selects a subject, and all relevant reports are displayed for that subject on the same page.

- Modified `faculty.py` to remove the report dropdown and display all reports for a selected subject.
- Updated `helpers/faculty_helper.py` to allow filtering grade distribution by subject.
- Modified all panel files (`student_progress_tracker.py`, `subject_difficulty_heatmap.py`, `intervention_candidates_list.py`, `grade_submission_status.py`, `custom_query_builder.py`) to accept a `subject_code` and filter their data accordingly.