### PR TITLE
fix: Resolve ModuleNotFoundError on startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "codespaces": {
       "openFiles": [
         "README.md",
-        "app.py"
+        "app/app.py"
       ]
     },
     "vscode": {
@@ -19,7 +19,7 @@
   },
   "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
   "postAttachCommand": {
-    "server": "streamlit run app.py --server.enableCORS false --server.enableXsrfProtection false"
+    "server": "python -m streamlit run app/app.py --server.enableCORS false --server.enableXsrfProtection false"
   },
   "portsAttributes": {
     "8501": {

--- a/scripts/runapp.cmd
+++ b/scripts/runapp.cmd
@@ -1,1 +1,1 @@
-streamlit run app/app.py
+python -m streamlit run app/app.py


### PR DESCRIPTION
The application was failing to start due to a ModuleNotFoundError. This was caused by an incorrect Python path when running the Streamlit application.

This change updates the run commands in scripts/runapp.cmd and .devcontainer/devcontainer.json to use 'python -m streamlit run app/app.py'.

Using the '-m' flag adds the project root to the Python path, which allows the application's internal imports to be resolved correctly.

This is the most direct and least invasive way to fix the issue without refactoring all the import statements in the codebase.